### PR TITLE
Add Datepicker examples and birthdate input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0-beta.6] - 2026-01-08
+
+### Added
+- **Form**: Added `setValue` method to useForm hook to allow programmatic field value updates
+- **Example**: Added birthdate input field with calendar icon in home page form
+
+### Fixed
+- **Form**: Fixed modal datepicker not opening on first click by wrapping input in clickable div
+
 ## [1.0.0-beta.5] - 2026-01-08
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@keymax-dev/smartepi-ui",
-	"version": "1.0.0-beta.4",
+	"version": "1.0.0-beta.5",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@keymax-dev/smartepi-ui",
-			"version": "1.0.0-beta.4",
+			"version": "1.0.0-beta.5",
 			"devDependencies": {
 				"@biomejs/biome": "2.3.11",
 				"@rollup/plugin-image": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keymax-dev/smartepi-ui",
-	"version": "1.0.0-beta.5",
+	"version": "1.0.0-beta.6",
 	"type": "module",
 	"main": "build/index.js",
 	"module": "build/index.esm.js",

--- a/src/app/pages/home/index.tsx
+++ b/src/app/pages/home/index.tsx
@@ -79,6 +79,7 @@ interface FormData {
 	name: string;
 	email: string;
 	password: string;
+	birthdate: string;
 	bio: string;
 	country: string;
 	terms: boolean;
@@ -126,6 +127,10 @@ export function HomePage(): React.JSX.Element {
 				(v: string) => (v.length >= 6 ? null : 'Mínimo 6 caracteres'),
 			],
 		},
+		birthdate: {
+			value: '',
+			validators: [(v: string) => (v ? null : 'Data de nascimento é obrigatória')],
+		},
 		bio: { value: '' },
 		country: { value: '' },
 		terms: {
@@ -144,6 +149,30 @@ export function HomePage(): React.JSX.Element {
 		} else {
 			toast.error('Por favor, corrija os erros no formulário');
 		}
+	};
+
+	const showDatePicker = () => {
+		modal.setContent(
+			<CardBase style={{ padding: '30px' }}>
+				<h2 style={{ marginTop: 0, marginBottom: '20px' }}>Selecione sua data de nascimento</h2>
+				<Datepicker
+					initial={form.getValues().birthdate ? new Date(form.getValues().birthdate) : undefined}
+					onDaySelected={(day) => {
+						const formattedDate = day.toLocaleDateString('pt-BR');
+						form.setValue('birthdate', formattedDate);
+						toast.success(`Data selecionada: ${formattedDate}`);
+						modal.close();
+					}}
+				/>
+				<Button
+					text="Fechar"
+					onClick={() => modal.close()}
+					color="secondary"
+					style={{ marginTop: '20px', width: '100%' }}
+				/>
+			</CardBase>,
+		);
+		modal.open();
 	};
 
 	const showModal = () => {
@@ -269,7 +298,15 @@ export function HomePage(): React.JSX.Element {
 								containerType="outline"
 								iconLeft="lock"
 							/>
-
+						<Input
+							{...form.getFieldProps('birthdate')}
+							placeholder="Data de nascimento"
+							containerType="outline"
+							iconLeft="calendar"
+							readOnly
+							onClick={showDatePicker}
+							style={{ cursor: 'pointer' }}
+						/>
 							<Select
 								{...form.getFieldProps('country')}
 								placeholder="Selecione um país"

--- a/src/app/pages/home/index.tsx
+++ b/src/app/pages/home/index.tsx
@@ -129,7 +129,9 @@ export function HomePage(): React.JSX.Element {
 		},
 		birthdate: {
 			value: '',
-			validators: [(v: string) => (v ? null : 'Data de nascimento é obrigatória')],
+			validators: [
+				(v: string) => (v ? null : 'Data de nascimento é obrigatória'),
+			],
 		},
 		bio: { value: '' },
 		country: { value: '' },
@@ -154,9 +156,15 @@ export function HomePage(): React.JSX.Element {
 	const showDatePicker = () => {
 		modal.setContent(
 			<CardBase style={{ padding: '30px' }}>
-				<h2 style={{ marginTop: 0, marginBottom: '20px' }}>Selecione sua data de nascimento</h2>
+				<h2 style={{ marginTop: 0, marginBottom: '20px' }}>
+					Selecione sua data de nascimento
+				</h2>
 				<Datepicker
-					initial={form.getValues().birthdate ? new Date(form.getValues().birthdate) : undefined}
+					initial={
+						form.getValues().birthdate
+							? new Date(form.getValues().birthdate)
+							: undefined
+					}
 					onDaySelected={(day) => {
 						const formattedDate = day.toLocaleDateString('pt-BR');
 						form.setValue('birthdate', formattedDate);
@@ -298,15 +306,17 @@ export function HomePage(): React.JSX.Element {
 								containerType="outline"
 								iconLeft="lock"
 							/>
-						<Input
-							{...form.getFieldProps('birthdate')}
-							placeholder="Data de nascimento"
-							containerType="outline"
-							iconLeft="calendar"
-							readOnly
-							onClick={showDatePicker}
-							style={{ cursor: 'pointer' }}
-						/>
+
+							<div onClick={showDatePicker} style={{ cursor: 'pointer' }}>
+								<Input
+									{...form.getFieldProps('birthdate')}
+									placeholder="Data de nascimento"
+									containerType="outline"
+									iconLeft="calendar"
+									readOnly
+								/>
+							</div>
+
 							<Select
 								{...form.getFieldProps('country')}
 								placeholder="Selecione um país"

--- a/src/app/pages/home/index.tsx
+++ b/src/app/pages/home/index.tsx
@@ -6,6 +6,7 @@ import {
 	Button,
 	CardBase,
 	Checkbox,
+	Datepicker,
 	Form,
 	Icon,
 	ImageAvatar,
@@ -92,6 +93,7 @@ const tableData = [
 export function HomePage(): React.JSX.Element {
 	const [_selectedTab, setSelectedTab] = useState(0);
 	const [checkboxValue, setCheckboxValue] = useState(false);
+	const [selectedDate, setSelectedDate] = useState<Date | undefined>();
 	const modal = useModal(<div />);
 	const toastController = useToast(<div />);
 
@@ -310,7 +312,47 @@ export function HomePage(): React.JSX.Element {
 				</Section>
 
 				<Section>
-					<SectionTitle>🗂️ Tabs e Conteúdo</SectionTitle>
+					<SectionTitle>� Datepicker</SectionTitle>
+					<Grid>
+						<CardBase>
+							<h3>Seletor de Data</h3>
+							<Datepicker
+								initial={selectedDate}
+								onDaySelected={(day) => {
+									setSelectedDate(day);
+									toast.success(
+										`Data selecionada: ${day.toLocaleDateString('pt-BR')}`,
+									);
+								}}
+							/>
+							{selectedDate && (
+								<p style={{ marginTop: '15px', textAlign: 'center' }}>
+									<strong>Data selecionada:</strong>{' '}
+									{selectedDate.toLocaleDateString('pt-BR', {
+										weekday: 'long',
+										year: 'numeric',
+										month: 'long',
+										day: 'numeric',
+									})}
+								</p>
+							)}
+						</CardBase>
+
+						<CardBase>
+							<h3>Datepicker Customizado</h3>
+							<Datepicker
+								width="100%"
+								height="350px"
+								onDaySelected={(day) => {
+									toast.info(`Dia ${day.getDate()} selecionado`);
+								}}
+							/>
+						</CardBase>
+					</Grid>
+				</Section>
+
+				<Section>
+					<SectionTitle>�🗂️ Tabs e Conteúdo</SectionTitle>
 					<CardBase>
 						<Tabs onTabChange={setSelectedTab}>
 							<Tab title="Perfil">

--- a/src/lib/components/Form/use-form.tsx
+++ b/src/lib/components/Form/use-form.tsx
@@ -102,13 +102,20 @@ function useFormObject<T extends FormPrototype>(
 		};
 	};
 
+	const setValue = (key: keyof T, value: any): void => {
+		const [state] = fieldStates[key as string];
+		if (state) {
+			state.value = value;
+		}
+	};
+
 	useEffect(() => {
 		return () => {
 			formMemory[formKey] = {};
 		};
 	}, [formKey]);
 
-	return { validate: validateForm, getValues, reset, getFieldProps };
+	return { validate: validateForm, getValues, reset, getFieldProps, setValue };
 }
 
 // Sobrecarga: aceita objeto com estrutura { field: { value, validators } }
@@ -120,6 +127,7 @@ export function useForm<T extends FormPrototype>(
 	getValues: () => T;
 	reset: () => void;
 	getFieldProps: (key: keyof T) => any;
+	setValue: (key: keyof T, value: any) => void;
 };
 
 // Sobrecarga original: aceita array


### PR DESCRIPTION
Introduce a birthdate input field with a calendar icon that opens a modal datepicker. Update the changelog to reflect these additions and fix an issue with the datepicker not opening on the first click.